### PR TITLE
Add config option for horizontal potion HUD layout

### DIFF
--- a/src/main/java/org/blockartistry/mod/DynSurround/ModOptions.java
+++ b/src/main/java/org/blockartistry/mod/DynSurround/ModOptions.java
@@ -333,9 +333,10 @@ public final class ModOptions {
 	public static final String CONFIG_POTION_HUD_LEFT_OFFSET = "Left Offset";
 	public static final String CONFIG_POTION_HUD_TOP_OFFSET = "Top Offset";
 	public static final String CONFIG_POTION_HUD_SCALE = "Display Scale";
+	public static final String CONFIG_POTION_HUD_HORIZONTAL = "Horizontal Layout";
 	private static final List<String> potionHudSort = Arrays.asList(CONFIG_POTION_HUD_ENABLE,
 			CONFIG_POTION_HUD_TRANSPARENCY, CONFIG_POTION_HUD_SCALE, CONFIG_POTION_HUD_TOP_OFFSET,
-			CONFIG_POTION_HUD_LEFT_OFFSET);
+			CONFIG_POTION_HUD_LEFT_OFFSET, CONFIG_POTION_HUD_HORIZONTAL);
 
 	@Parameter(category = CATEGORY_POTION_HUD, property = CONFIG_POTION_HUD_ENABLE, defaultValue = "true")
 	@Comment("Enable display of potion icons in display")
@@ -357,6 +358,9 @@ public final class ModOptions {
 	@MinMaxFloat(min = 0.0F, max = 1.0F)
 	@Comment("Size scale of icons (lower is smaller)")
 	public static float potionHudScale = 0.5F;
+	@Parameter(category = CATEGORY_POTION_HUD, property = CONFIG_POTION_HUD_HORIZONTAL, defaultValue = "false")
+	@Comment("Lay out potion effects in a horizontal row instead of a vertical column")
+	public static boolean potionHudHorizontal = false;
 
 	public static void load(final Configuration config) {
 

--- a/src/main/java/org/blockartistry/mod/DynSurround/client/hud/PotionHUD.java
+++ b/src/main/java/org/blockartistry/mod/DynSurround/client/hud/PotionHUD.java
@@ -69,7 +69,7 @@ public class PotionHUD extends Gui implements IGuiOverlay {
 		final FontRenderer font = mc.fontRenderer;
 		final EntityPlayer player = Minecraft.getMinecraft().thePlayer;
 
-		final int guiLeft = 2;
+		int guiLeft = 2;
 		int guiTop = 2;
 
 		final Collection<PotionEffect> collection = player.getActivePotionEffects();
@@ -81,13 +81,20 @@ public class PotionHUD extends Gui implements IGuiOverlay {
 			GL11.glDisable(GL11.GL_LIGHTING);
 			GL11.glTranslatef(GUILEFT, GUITOP, 0.0F);
 			GL11.glScalef(SCALE, SCALE, SCALE);
-			int k = 33;
+			final boolean horizontal = ModOptions.potionHudHorizontal;
 
-			if (collection.size() > 7) {
-				k = 198 / (collection.size() - 1);
+			// Vertical spacing collapses as more effects stack up; the horizontal
+			// layout instead advances by a fixed element width. Only one of the two
+			// steps is non-zero, so the same loop drives either direction.
+			int verticalStep = 33;
+			if (!horizontal && collection.size() > 7) {
+				verticalStep = 198 / (collection.size() - 1);
 			}
 
-			for (final Iterator<PotionEffect> iterator = collection.iterator(); iterator.hasNext(); guiTop += k) {
+			final int rowStep = horizontal ? 0 : verticalStep;
+			final int colStep = horizontal ? 120 : 0;
+
+			for (final Iterator<PotionEffect> iterator = collection.iterator(); iterator.hasNext(); guiTop += rowStep, guiLeft += colStep) {
 				final PotionEffect potioneffect = iterator.next();
 				final int potionId = potioneffect.getPotionID();
 				if (potionId < 0 || potionId >= Potion.potionTypes.length)


### PR DESCRIPTION
As discussed, this makes the horizontal potion HUD layout opt-in instead of forced. New Horizontal Layout toggle under player.potion hud, default off so existing setups render exactly as before. Tested both states in-game.